### PR TITLE
Remove need for randomNoteFromRandomNotebook, closes #11

### DIFF
--- a/server/api/notes.js
+++ b/server/api/notes.js
@@ -2,5 +2,4 @@ module.exports = (notes_routes) => {
   const notes = require('../controllers/notes')
   notes_routes.get('/notebooks', notes.notebooks)
   notes_routes.get('/randomNote', notes.randomNote)
-  notes_routes.get('/randomNoteFromRandomNotebook', notes.randomNoteFromRandomNotebook)
 }

--- a/server/controllers/notes.js
+++ b/server/controllers/notes.js
@@ -10,16 +10,8 @@ async function notebooks(req, res) {
 }
 
 async function randomNote(req, res) {
-  const randomNote = await evernote.randomNote(req.query.guid, req.session.accessToken)
-  res.status(200).json({
-    note: randomNote,
-    edamUserId: req.session.edamUserId,
-    edamShard: req.session.edamShard,
-  })
-}
-
-async function randomNoteFromRandomNotebook(req, res) {
-  const randomNote = await evernote.randomNoteFromRandomNotebook(req.session.accessToken)
+  const guid = req.query.guid || evernote.randomNotebook(req.session.accessToken).guid
+  const randomNote = await evernote.randomNote(req.session.accessToken, guid)
   res.status(200).json({
     note: randomNote,
     edamUserId: req.session.edamUserId,
@@ -29,4 +21,3 @@ async function randomNoteFromRandomNotebook(req, res) {
 
 exports.notebooks = notebooks
 exports.randomNote = randomNote
-exports.randomNoteFromRandomNotebook = randomNoteFromRandomNotebook

--- a/server/index.js
+++ b/server/index.js
@@ -15,14 +15,14 @@ app.use(bodyParser.urlencoded({ extended: false }))
 app.use(bodyParser.json())
 
 
-//// comment-out locally
+//// comment-out locally, uncomment on glitch/prod - see https://github.com/galtenberg/evernote-random/issues/2
 // Serve static assets
 //app.use(express.static(path.resolve(__dirname, '..', 'build')))
 // Always return the main index.html, so react-router renders the route in the client
 //app.get(['/', '/auth*', '/randomInApp', '/random-in-app'], (req, res) => {
   //res.sendFile(path.resolve(__dirname, '..', 'build', 'index.html'));
 //})
-//// end comment-out locally
+//// end comment-out locally, uncomment on glitch/prod
 
 
 app.use(cookieSession({

--- a/server/lib/evernote/evernote.js
+++ b/server/lib/evernote/evernote.js
@@ -8,17 +8,13 @@ function notebooks(token) {
   return client.getNoteStore().listNotebooks()
 }
 
-async function randomNoteFromRandomNotebook(token) {
-  return randomNote(randomNotebook(token).guid, token)
-}
-
 async function randomNotebook(token) {
   const notebooksSet = await notebooks(token)
   const randomNoteIndex = getRandomInt(0, [notebooksSet].length)
   return notebooksSet[randomNoteIndex]
 }
 
-async function randomNote(notebookGuid, token) {
+async function randomNote(token, notebookGuid) {
   const client = enAuth.createAuthenticatedClient(token)
   const noteStore = client.getNoteStore()
 
@@ -51,7 +47,6 @@ async function randomNote(notebookGuid, token) {
   .catch(err => err)
 }
 
-exports.randomNoteFromRandomNotebook = randomNoteFromRandomNotebook
 exports.randomNotebook = randomNotebook
 exports.randomNote = randomNote
 exports.notebooks = notebooks

--- a/src/components/Notes/Random.js
+++ b/src/components/Notes/Random.js
@@ -11,7 +11,7 @@ export default class Random extends Component {
     var response, note
 
     try {
-      const url = new URL('/randomNoteFromRandomNotebook', rootUrl)
+      const url = new URL('/randomNote', rootUrl)
       for (var i = 0; i < 3; i++) {
         response = await fetch(url, fetchCred)
         note = await response.json()


### PR DESCRIPTION
Retrieve guid via `randomNotebook()` call if necessary.